### PR TITLE
UI Refinement

### DIFF
--- a/app/src/main/java/app/luma/style/SettingsTheme.kt
+++ b/app/src/main/java/app/luma/style/SettingsTheme.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.unit.sp
 import app.luma.R
 import app.luma.data.Prefs
@@ -80,12 +79,6 @@ fun SettingsTheme(
                     fontFamily = FontFamily(Font(R.font.public_sans)),
                     fontSize = 32.sp,
                     color = textColor,
-                    lineHeight = 20.sp,
-                    lineHeightStyle =
-                        LineHeightStyle(
-                            alignment = LineHeightStyle.Alignment.Bottom,
-                            trim = LineHeightStyle.Trim.Both,
-                        ),
                     platformStyle = PlatformTextStyle(includeFontPadding = false),
                 ),
             button =

--- a/app/src/main/java/app/luma/ui/AppActionsFragment.kt
+++ b/app/src/main/java/app/luma/ui/AppActionsFragment.kt
@@ -124,7 +124,7 @@ class AppActionsFragment : Fragment() {
                 onBack = ::goBack,
             )
             ContentContainer {
-                CustomScrollView(verticalArrangement = Arrangement.spacedBy(40.dp)) {
+                CustomScrollView(verticalArrangement = Arrangement.spacedBy(33.5.dp)) {
                     SimpleTextButton(stringResource(R.string.app_actions_rename)) {
                         findNavController().navigate(
                             R.id.renameFragment,

--- a/app/src/main/java/app/luma/ui/GesturesFragment.kt
+++ b/app/src/main/java/app/luma/ui/GesturesFragment.kt
@@ -44,7 +44,7 @@ class GesturesFragment : Fragment() {
             )
 
             ContentContainer {
-                CustomScrollView(verticalArrangement = Arrangement.spacedBy(26.dp)) {
+                CustomScrollView(verticalArrangement = Arrangement.spacedBy(33.5.dp)) {
                     GestureButton(stringResource(R.string.gesture_swipe_left), GestureType.SWIPE_LEFT)
                     GestureButton(stringResource(R.string.gesture_swipe_right), GestureType.SWIPE_RIGHT)
                     GestureButton(stringResource(R.string.gesture_swipe_down), GestureType.SWIPE_DOWN)

--- a/app/src/main/java/app/luma/ui/NotificationsFragment.kt
+++ b/app/src/main/java/app/luma/ui/NotificationsFragment.kt
@@ -44,7 +44,7 @@ class NotificationsFragment : Fragment() {
                 onBack = ::goBack,
             )
 
-            ContentContainer(verticalArrangement = Arrangement.spacedBy(45.dp)) {
+            ContentContainer(verticalArrangement = Arrangement.spacedBy(33.5.dp)) {
                 SimpleTextButton(stringResource(R.string.notifications_grant_permissions)) {
                     openNotificationListenerSettings()
                 }

--- a/app/src/main/java/app/luma/ui/PagesFragment.kt
+++ b/app/src/main/java/app/luma/ui/PagesFragment.kt
@@ -46,7 +46,7 @@ class PagesFragment : Fragment() {
             )
 
             ContentContainer {
-                CustomScrollView(verticalArrangement = Arrangement.spacedBy(26.dp)) {
+                CustomScrollView(verticalArrangement = Arrangement.spacedBy(33.5.dp)) {
                     SelectorButton(
                         label = stringResource(R.string.pages_page_indicator_position),
                         value =

--- a/app/src/main/java/app/luma/ui/SettingsFragment.kt
+++ b/app/src/main/java/app/luma/ui/SettingsFragment.kt
@@ -54,21 +54,21 @@ class SettingsFragment : Fragment() {
             val invertState = remember { mutableStateOf(prefs.invertColours) }
 
             ContentContainer {
-                CustomScrollView(verticalArrangement = Arrangement.spacedBy(24.dp)) {
-                    // ToggleTextButton(
-                    //     title = stringResource(R.string.settings_invert_colours),
-                    //     checked = invertState.value,
-                    //     onCheckedChange = {
-                    //         invertState.value = it
-                    //         prefs.invertColours = it
-                    //         requireActivity().recreate()
-                    //     },
-                    //     onClick = {
-                    //         invertState.value = !invertState.value
-                    //         prefs.invertColours = invertState.value
-                    //         requireActivity().recreate()
-                    //     },
-                    // )
+                CustomScrollView(verticalArrangement = Arrangement.spacedBy(33.5.dp)) {
+                    ToggleTextButton(
+                        title = stringResource(R.string.settings_invert_colours),
+                        checked = invertState.value,
+                        onCheckedChange = {
+                            invertState.value = it
+                            prefs.invertColours = it
+                            requireActivity().recreate()
+                        },
+                        onClick = {
+                            invertState.value = !invertState.value
+                            prefs.invertColours = invertState.value
+                            requireActivity().recreate()
+                        },
+                    )
                     SimpleTextButton(
                         stringResource(R.string.settings_pages),
                     ) { findNavController().navigate(R.id.action_settingsFragment_to_pagesFragment) }

--- a/app/src/main/java/app/luma/ui/compose/CustomScrollView.kt
+++ b/app/src/main/java/app/luma/ui/compose/CustomScrollView.kt
@@ -26,7 +26,7 @@ import kotlin.math.max
 @Composable
 fun CustomScrollView(
     modifier: Modifier = Modifier,
-    verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(46.dp),
+    verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(33.5.dp),
     content: @Composable () -> Unit,
 ) {
     var contentHeightPx by remember { mutableStateOf(0) }

--- a/app/src/main/java/app/luma/ui/compose/SettingsComposable.kt
+++ b/app/src/main/java/app/luma/ui/compose/SettingsComposable.kt
@@ -139,7 +139,9 @@ object SettingsComposable {
             verticalAlignment = Alignment.CenterVertically,
         ) {
             CustomToggleSwitch(checked = checked, onCheckedChange = onCheckedChange)
-            SimpleTextButton(title = title, fontSize = fontSize, onClick = onClick)
+            Box(modifier = Modifier.offset(y = (5).dp)) {
+                SimpleTextButton(title = title, fontSize = fontSize, onClick = onClick)
+            }
         }
     }
 
@@ -207,7 +209,7 @@ object SettingsComposable {
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(top = 0.dp, bottom = 20.dp, start = 26.dp, end = 0.dp),
+                    .padding(top = 0.dp, bottom = 28.dp, start = 26.dp, end = 0.dp),
             verticalArrangement = verticalArrangement,
         ) {
             content()
@@ -244,6 +246,7 @@ object SettingsComposable {
                 modifier =
                     Modifier
                         .align(Alignment.CenterStart)
+                        .offset(y = (-5.5).dp)
                         .clickable {
                             performHapticFeedback(context)
                             onClick()


### PR DESCRIPTION
UI element sizing and padding slightly adjusted to better match LightOS
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vandamd/luma/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
