### PR TITLE
Hide grouped notification summaries when children exist

### DIFF
--- a/app/src/main/java/app/luma/ui/NotificationListFragment.kt
+++ b/app/src/main/java/app/luma/ui/NotificationListFragment.kt
@@ -84,12 +84,22 @@ class NotificationListFragment : Fragment() {
     @Suppress("DEPRECATION")
     private fun loadNotifications(): List<NotificationItem> {
         val pm = requireContext().packageManager
-        return LumaNotificationListener
-            .getActiveNotifications()
-            .filter { !it.isOngoing }
+        val nonOngoing =
+            LumaNotificationListener
+                .getActiveNotifications()
+                .filter { !it.isOngoing }
+        val groupKeysWithChildren =
+            nonOngoing
+                .filterNot { it.isGroupSummary() }
+                .map { it.groupKey }
+                .toSet()
+        return nonOngoing
+            .filterNot { it.isGroupSummary() && it.groupKey in groupKeysWithChildren }
             .map { sbn -> sbn.toNotificationItem(pm) }
             .sortedBy { it.title.lowercase() }
     }
+
+    private fun StatusBarNotification.isGroupSummary(): Boolean = notification.flags and Notification.FLAG_GROUP_SUMMARY != 0
 
     @Suppress("DEPRECATION")
     private fun StatusBarNotification.toNotificationItem(pm: android.content.pm.PackageManager): NotificationItem {


### PR DESCRIPTION
## Summary
- stop rendering notification group summaries when non-summary notifications exist in the same `groupKey`
- keep summary notifications as fallback when they are the only visible item in a group
- this targets duplicate-looking WhatsApp rows caused by summary + child both appearing

## Testing
- ./gradlew ktlintCheck testDebugUnitTest
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vandamd/luma/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
